### PR TITLE
Extract output coords instead of inputs

### DIFF
--- a/Doc/tutorials/basic/basic_012.ipynb
+++ b/Doc/tutorials/basic/basic_012.ipynb
@@ -196,7 +196,7 @@
     "Bohr2Angstrom = 0.529177\n",
     "\n",
     "# extract atomic coordinates\n",
-    "atomic_structure = root.find('input/atomic_structure')\n",
+    "atomic_structure = root.find('output/atomic_structure')\n",
     "alat = float(atomic_structure.attrib['alat'])\n",
     "atoms = atomic_structure.findall('atomic_positions/atom')\n",
     "gs_geo = [np.array(atom.text.split(), dtype=np.float64) * Bohr2Angstrom for atom in atoms]"
@@ -639,7 +639,7 @@
     "\n",
     "xmlData = ET.parse(fname)\n",
     "root = xmlData.getroot()\n",
-    "atomic_structure = root.find('input/atomic_structure')\n",
+    "atomic_structure = root.find('output/atomic_structure')\n",
     "alat = float(atomic_structure.attrib['alat'])\n",
     "atoms = atomic_structure.findall('atomic_positions/atom')\n",
     "es_geo = [np.array(atom.text.split(), dtype=np.float64) * Bohr2Angstrom for atom in atoms]"


### PR DESCRIPTION
Changes the coordinates read in the example script from input to output geometry.